### PR TITLE
Fix build error due to missing signal.h

### DIFF
--- a/src/SlackUI.cpp
+++ b/src/SlackUI.cpp
@@ -1,4 +1,5 @@
 #include "SlackUI.hpp"
+#include "signal.h"
 
 static bool quit = false;
 


### PR DESCRIPTION
This fixes:

```
target slack++
[ 11%] Building CXX object CMakeFiles/slack++.dir/src/SlackUI.cpp.o
/home/fredrick/Workspace/slack/src/SlackUI.cpp: In member function 'void SlackUI::main_ui_cycle()':
/home/fredrick/Workspace/slack/src/SlackUI.cpp:65:22: error: variable 'SlackUI::main_ui_cycle()::sigaction main_act' has initializer but incomplete type
     struct sigaction main_act = {{0}};
                      ^~~~~~~~
/home/fredrick/Workspace/slack/src/SlackUI.cpp:69:15: error: 'SIGINT' was not declared in this scope
     sigaction(SIGINT, &main_act, 0);
               ^~~~~~
/home/fredrick/Workspace/slack/src/SlackUI.cpp:69:35: error: invalid use of incomplete type 'struct SlackUI::main_ui_cycle()::sigaction'
     sigaction(SIGINT, &main_act, 0);
                                   ^
/home/fredrick/Workspace/slack/src/SlackUI.cpp:65:12: note: forward declaration of 'struct SlackUI::main_ui_cycle()::sigaction'
     struct sigaction main_act = {{0}};
            ^~~~~~~~~
/home/fredrick/Workspace/slack/src/SlackUI.cpp:70:15: error: 'SIGTERM' was not declared in this scope
     sigaction(SIGTERM, &main_act, 0);
               ^~~~~~~
/home/fredrick/Workspace/slack/src/SlackUI.cpp:70:36: error: invalid use of incomplete type 'struct SlackUI::main_ui_cycle()::sigaction'
     sigaction(SIGTERM, &main_act, 0);
                                    ^
/home/fredrick/Workspace/slack/src/SlackUI.cpp:65:12: note: forward declaration of 'struct SlackUI::main_ui_cycle()::sigaction'
     struct sigaction main_act = {{0}};
            ^~~~~~~~~
/home/fredrick/Workspace/slack/src/SlackUI.cpp:71:22: error: 'sigemptyset' was not declared in this scope
     sigemptyset(&mask);
                      ^
/home/fredrick/Workspace/slack/src/SlackUI.cpp:72:28: error: 'sigaddset' was not declared in this scope
     sigaddset(&mask, SIGINT);
                            ^
/home/fredrick/Workspace/slack/src/SlackUI.cpp:74:17: error: 'SIG_BLOCK' was not declared in this scope
     sigprocmask(SIG_BLOCK, &mask, &main_mask);
                 ^~~~~~~~~
/home/fredrick/Workspace/slack/src/SlackUI.cpp:74:45: error: 'sigprocmask' was not declared in this scope
     sigprocmask(SIG_BLOCK, &mask, &main_mask);
                                             ^
make[2]: *** [CMakeFiles/slack++.dir/build.make:111: CMakeFiles/slack++.dir/src/SlackUI.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:68: CMakeFiles/slack++.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```

There might be a better cmake way to do it, but I don't know what that would be.